### PR TITLE
Integrate other trainings with config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ python src/train.py data=classifier model=classifier_ssl_frozen callbacks=classi
 # python src/train.py data=classifier model=classifier_untrained callbacks=classifier_untrained_train_callback
 
 # evaluate model with VICREG backbone and frozen weights on test dataset
-python src/eval.py callbacks=classifier_ssl_frozen_eval_callback
+python src/eval.py +callbacks=classifier_ssl_frozen_eval_callback
 ```
 
 You can override any parameter from command line like this

--- a/README.md
+++ b/README.md
@@ -129,11 +129,23 @@ Train model with default configuration
 # train VICREG
 python src/train.py
 
-# train Classifier with VICREG backbone
-python src/train.py model=classifier callbacks=classifier_train_callback
+# train Classifier with VICREG backbone and frozen weights
+python src/train.py data=classifier model=classifier_ssl_frozen callbacks=classifier_ssl_frozen_train_callback
 
-# evaluate model on test dataset
-python src/eval.py model=classifier callbacks=classifier_eval_callback
+# train Classifier with VICREG backbone and NOT frozen weights
+# python src/train.py data=classifier model=classifier_ssl_not_frozen callbacks=classifier_ssl_not_frozen_train_callback
+
+# train Classifier without SSL, but pretrained backbone and frozen weights
+# python src/train.py data=classifier model=classifier_pretrained_frozen callbacks=classifier_pretrained_frozen_train_callback
+
+# train Classifier without SSL, but pretrained backbone and NOT frozen weights
+# python src/train.py data=classifier model=classifier_pretrained_not_frozen callbacks=classifier_pretrained_not_frozen_train_callback
+
+# train Classifier with untrained backbone
+# python src/train.py data=classifier model=classifier_untrained callbacks=classifier_untrained_train_callback
+
+# evaluate model with VICREG backbone and frozen weights on test dataset
+python src/eval.py callbacks=classifier_ssl_frozen_eval_callback
 ```
 
 You can override any parameter from command line like this

--- a/configs/callbacks/classifier_pretrained_frozen_eval_callback.yaml
+++ b/configs/callbacks/classifier_pretrained_frozen_eval_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_pretrained_frozen_classifier' # checkpoint filename
+  monitor: 'val_acc' # name of the logged metric which determines when model is improving
+  mode: "max"
+
+early_stopping:
+  monitor: "val_acc"
+  patience: 100
+  mode: "max"

--- a/configs/callbacks/classifier_pretrained_frozen_train_callback.yaml
+++ b/configs/callbacks/classifier_pretrained_frozen_train_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_pretrained_frozen' # checkpoint filename
+  monitor: 'classifier_loss' # name of the logged metric which determines when model is improving
+  mode: "min"
+
+early_stopping:
+  monitor: "classifier_loss"
+  patience: 100
+  mode: "min"

--- a/configs/callbacks/classifier_pretrained_not_frozen_eval_callback.yaml
+++ b/configs/callbacks/classifier_pretrained_not_frozen_eval_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_pretrained_not_frozen_classifier' # checkpoint filename
+  monitor: 'val_acc' # name of the logged metric which determines when model is improving
+  mode: "max"
+
+early_stopping:
+  monitor: "val_acc"
+  patience: 100
+  mode: "max"

--- a/configs/callbacks/classifier_pretrained_not_frozen_train_callback.yaml
+++ b/configs/callbacks/classifier_pretrained_not_frozen_train_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_pretrained_not_frozen' # checkpoint filename
+  monitor: 'classifier_loss' # name of the logged metric which determines when model is improving
+  mode: "min"
+
+early_stopping:
+  monitor: "classifier_loss"
+  patience: 100
+  mode: "min"

--- a/configs/callbacks/classifier_ssl_frozen_eval_callback.yaml
+++ b/configs/callbacks/classifier_ssl_frozen_eval_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_ssl_frozen_classifier' # checkpoint filename
+  monitor: 'val_acc' # name of the logged metric which determines when model is improving
+  mode: "max"
+
+early_stopping:
+  monitor: "val_acc"
+  patience: 100
+  mode: "max"

--- a/configs/callbacks/classifier_ssl_frozen_train_callback.yaml
+++ b/configs/callbacks/classifier_ssl_frozen_train_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_ssl_frozen' # checkpoint filename
+  monitor: 'classifier_loss' # name of the logged metric which determines when model is improving
+  mode: "min"
+
+early_stopping:
+  monitor: "classifier_loss"
+  patience: 100
+  mode: "min"

--- a/configs/callbacks/classifier_ssl_not_frozen_eval_callback.yaml
+++ b/configs/callbacks/classifier_ssl_not_frozen_eval_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_ssl_not_frozen_classifier' # checkpoint filename
+  monitor: 'val_acc' # name of the logged metric which determines when model is improving
+  mode: "max"
+
+early_stopping:
+  monitor: "val_acc"
+  patience: 100
+  mode: "max"

--- a/configs/callbacks/classifier_ssl_not_frozen_train_callback.yaml
+++ b/configs/callbacks/classifier_ssl_not_frozen_train_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_ssl_not_frozen' # checkpoint filename
+  monitor: 'classifier_loss' # name of the logged metric which determines when model is improving
+  mode: "min"
+
+early_stopping:
+  monitor: "classifier_loss"
+  patience: 100
+  mode: "min"

--- a/configs/callbacks/classifier_untrained_eval_callback.yaml
+++ b/configs/callbacks/classifier_untrained_eval_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_untrained_classifier' # checkpoint filename
+  monitor: 'val_acc' # name of the logged metric which determines when model is improving
+  mode: "max"
+
+early_stopping:
+  monitor: "val_acc"
+  patience: 100
+  mode: "max"

--- a/configs/callbacks/classifier_untrained_train_callback.yaml
+++ b/configs/callbacks/classifier_untrained_train_callback.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.checkpoint_dir} # directory to save the model file
+  filename: 'best_model_with_untrained' # checkpoint filename
+  monitor: 'classifier_loss' # name of the logged metric which determines when model is improving
+  mode: "min"
+
+early_stopping:
+  monitor: "classifier_loss"
+  patience: 100
+  mode: "min"

--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -3,7 +3,7 @@
 defaults:
   - _self_
   - data: classifier # choose datamodule with `test_dataloader()` for evaluation
-  - model: classifier
+  - model: classifier_ssl_frozen
   - logger: null
   - trainer: default
   - paths: default
@@ -15,4 +15,4 @@ task_name: "eval"
 tags: ["dev"]
 
 # passing checkpoint path is necessary for evaluation
-ckpt_path: "${paths.checkpoint_dir}best_model_with_classifier.ckpt"
+ckpt_path: "${paths.checkpoint_dir}best_model_with_ssl_frozen.ckpt"

--- a/configs/model/classifier.yaml
+++ b/configs/model/classifier.yaml
@@ -1,4 +1,7 @@
 _target_: src.models.classifier_module.ClassifierModule
 backbone_ckpt_path: "${paths.checkpoint_dir}best_model_vicreg.ckpt"
+ssl_backbone: True
+backbone_pretrained: True
+freeze: True
 num_classes: 525
 max_epochs: 100

--- a/configs/model/classifier_pretrained_frozen.yaml
+++ b/configs/model/classifier_pretrained_frozen.yaml
@@ -1,0 +1,7 @@
+_target_: src.models.classifier_module.ClassifierModule
+backbone_ckpt_path: "${paths.checkpoint_dir}best_model_vicreg.ckpt"
+ssl_backbone: False
+backbone_pretrained: True
+freeze: True
+num_classes: 525
+max_epochs: 100

--- a/configs/model/classifier_pretrained_not_frozen.yaml
+++ b/configs/model/classifier_pretrained_not_frozen.yaml
@@ -1,0 +1,7 @@
+_target_: src.models.classifier_module.ClassifierModule
+backbone_ckpt_path: "${paths.checkpoint_dir}best_model_vicreg.ckpt"
+ssl_backbone: False
+backbone_pretrained: True
+freeze: False
+num_classes: 525
+max_epochs: 100

--- a/configs/model/classifier_ssl_frozen.yaml
+++ b/configs/model/classifier_ssl_frozen.yaml
@@ -1,0 +1,7 @@
+_target_: src.models.classifier_module.ClassifierModule
+backbone_ckpt_path: "${paths.checkpoint_dir}best_model_vicreg.ckpt"
+ssl_backbone: True
+backbone_pretrained: True
+freeze: True
+num_classes: 525
+max_epochs: 100

--- a/configs/model/classifier_ssl_not_frozen.yaml
+++ b/configs/model/classifier_ssl_not_frozen.yaml
@@ -1,0 +1,7 @@
+_target_: src.models.classifier_module.ClassifierModule
+backbone_ckpt_path: "${paths.checkpoint_dir}best_model_vicreg.ckpt"
+ssl_backbone: True
+backbone_pretrained: True
+freeze: False
+num_classes: 525
+max_epochs: 100

--- a/configs/model/classifier_untrained.yaml
+++ b/configs/model/classifier_untrained.yaml
@@ -1,0 +1,7 @@
+_target_: src.models.classifier_module.ClassifierModule
+backbone_ckpt_path: "${paths.checkpoint_dir}best_model_vicreg.ckpt"
+ssl_backbone: False
+backbone_pretrained: False
+freeze: False
+num_classes: 525
+max_epochs: 100

--- a/src/models/classifier_module.py
+++ b/src/models/classifier_module.py
@@ -78,7 +78,8 @@ class ClassifierModule(LightningModule):
         """
         x, y, _ = batch
         # x is list[torch.Tensor]
-        y_hat = self.forward(x[0])
+        #y_hat = self.forward(x[0])
+        y_hat = self.forward(x)
         loss = self.criterion(y_hat, y)
         self.log("classifier_loss", loss)
         return loss

--- a/src/models/classifier_module.py
+++ b/src/models/classifier_module.py
@@ -22,6 +22,9 @@ class ClassifierModule(LightningModule):
     def __init__(
         self,
         backbone_ckpt_path: str,
+        ssl_backbone: bool = True,
+        backbone_pretrained: bool = True,
+        freeze: bool = True,
         num_classes : int = 525,
         max_epochs: int = 100
     ) -> None:
@@ -29,16 +32,23 @@ class ClassifierModule(LightningModule):
         # this line allows to access init params with 'self.hparams' attribute
         self.save_hyperparameters(logger=False)
 
-        ckpt_path = backbone_ckpt_path
-        model = VICRegModule.load_from_checkpoint(ckpt_path)
-        model.eval()
-
-        # use the pretrained ResNet backbone
-        self.backbone = model.backbone
+        if(ssl_backbone):
+            # use the pretrained VICReg backbone
+            ckpt_path = backbone_ckpt_path
+            model = VICRegModule.load_from_checkpoint(ckpt_path)
+            model.eval()
+            self.backbone = model.backbone
+        else:
+            # without SSL pretraining
+            resnet = torchvision.models.resnet18(pretrained=backbone_pretrained)
+            backbone = nn.Sequential(*list(resnet.children())[:-1])
+            self.backbone = backbone
+        
         self.max_epochs = max_epochs
 
-        # freeze the backbone
-        deactivate_requires_grad(self.backbone)
+        if(freeze):
+            # freeze the backbone
+            deactivate_requires_grad(self.backbone)
 
         # create a linear layer for our downstream classification model
         self.fc = nn.Linear(512, num_classes)


### PR DESCRIPTION
#32 
- Integráció új config fájlokkal
   - minden futtatás kapott új model config-ot
   - minden futtatás kapott új callback-et tanításhoz
   - minden futtatás kapott új callback-et eval-hoz (csak egyet használunk tényleges eddig a README-ben, de van másikra is  lehetőség)
   - README módosítva az összes opció tanító futtatásához.
- Eval módosítva az új VICReg-es model tanításra + módosítva a callback
